### PR TITLE
Update escape_char.ipp

### DIFF
--- a/include/boost/spirit/home/classic/utility/impl/escape_char.ipp
+++ b/include/boost/spirit/home/classic/utility/impl/escape_char.ipp
@@ -166,7 +166,7 @@ namespace impl {
             return scan.no_match(); // overflow detected
         }
     };
-#if (defined(BOOST_MSVC) && (BOOST_MSVC <= 1310))
+#if defined(BOOST_MSVC)
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
fixed #pragma warning (push) / #pragma warning (pop) mismatch in escape_char.ipp when compiling with Visual Studio 2017 (#532)